### PR TITLE
Release v1.0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage/
 
 # 開発設定ファイル
 .eslintrc.js
+.serena/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.0.14] - 2026-03-25
+
+### Changed (1.0.14)
+
+- Bumped extension version to **1.0.14**.
+- Updated `README.md` to clarify that Go to Definition lands on the
+  exact message key definition in `.properties` files.
+
+### Fixed (1.0.14)
+
+- Fixed Go to Definition so it targets the message-key range itself,
+  instead of placing the cursor at the end of the `.properties` line.
+- Added regression test coverage for key-range based property
+  navigation.
+
 ## [1.0.13] - 2026-03-24
 
 ### Added (1.0.13)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/y-ok/java-message-key-navigator/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/y-ok/java-message-key-navigator/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/y-ok/java-message-key-navigator/branch/main/graph/badge.svg)](https://codecov.io/gh/y-ok/java-message-key-navigator)
 
-**Java Message Key Navigator** is a VS Code extension designed to supercharge your Java internationalization (I18N) workflow. Hover over any I18N method call to instantly preview the corresponding value from your `.properties` files, and use ⌘/Ctrl + click to jump straight to its definition. When a key is missing, you’ll see an automatic warning plus a one-click quick fix that inserts the new key in the correct sorted order—no more manual file edits or guesswork. With customizable extraction patterns and support for multiple property-file globs, this extension keeps your message keys organized and your development flow uninterrupted.
+**Java Message Key Navigator** is a VS Code extension designed to supercharge your Java internationalization (I18N) workflow. Hover over any I18N method call to instantly preview the corresponding value from your `.properties` files, and use ⌘/Ctrl + click to jump straight to the exact message-key definition. When a key is missing, you’ll see an automatic warning plus a one-click quick fix that inserts the new key in the correct sorted order—no more manual file edits or guesswork. With customizable extraction patterns and support for multiple property-file globs, this extension keeps your message keys organized and your development flow uninterrupted.
 
 ---
 
@@ -22,7 +22,7 @@ infrastructureLogger.log("PLF1001");
 and instantly see the localized message inline.
 
 **Go to Definition**
-Use ⌘ Click (macOS) or Ctrl Click to jump directly to the line in your `.properties` file where the key is defined.
+Use ⌘ Click (macOS) or Ctrl Click to jump directly to the exact message key in your `.properties` file.
 
 **Undefined Key Detection & Quick Fixes**
 When you use a key that doesn’t exist in any of your `.properties` files, a warning will appear automatically. The extension offers a quick fix that:
@@ -124,7 +124,7 @@ Add these to your **User** or **Workspace** `settings.json`:
    Hover over any supported method call to see the message value inline.
 
 2. **Definition**  
-   ⌘ Click / Ctrl Click to jump to the exact line in the `.properties` file.
+   ⌘ Click / Ctrl Click to jump to the exact message key in the `.properties` file.
 
 3. **Quick Fix**  
    When you see “Undefined message key” warnings, click the lightbulb or press `⌨️ Cmd/Ctrl + .` to add the missing key in the correct sorted position of your chosen file.
@@ -225,7 +225,7 @@ Add these to your **User** or **Workspace** `settings.json`:
      - executes `npm ci`, `npm run lint`, `npm test`, and `npm run build`
      - uploads coverage and generated VSIX as workflow artifacts
    - Release workflow: [.github/workflows/release.yml](.github/workflows/release.yml)
-     - runs only when a version tag such as `v1.0.13` is pushed
+     - runs only when a version tag such as `v1.0.14` is pushed
      - requires the pushed tag to match `package.json` version
      - reruns lint, tests, and `npm run benchmark:strict` before release upload
      - creates the GitHub Release if it does not exist yet, then uploads the generated VSIX

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "java-message-key-navigator",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "java-message-key-navigator",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Java Message Key Navigator",
   "description": "A VS Code extension to assist with Java I18N (internationalization) message management",
   "publisher": "y-ok",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -40,12 +40,9 @@ export class PropertiesDefinitionProvider implements vscode.DefinitionProvider {
         const loc = await findPropertyLocation(key);
         if (loc) {
           outputChannel.appendLine(
-            `🚀 Jump destination: ${loc.filePath}:${loc.position.line + 1}`
+            `🚀 Jump destination: ${loc.filePath}:${loc.range.start.line + 1}`
           );
-          return new vscode.Location(
-            vscode.Uri.file(loc.filePath),
-            loc.position
-          );
+          return new vscode.Location(vscode.Uri.file(loc.filePath), loc.range);
         } else {
           outputChannel.appendLine(`❌ Definition not found: ${key}`);
           return null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,7 +111,7 @@ export function getCustomPatterns(): RegExp[] {
  */
 export async function findPropertyLocation(
   key: string
-): Promise<{ filePath: string; position: vscode.Position } | null> {
+): Promise<{ filePath: string; range: vscode.Range } | null> {
   const config = vscode.workspace.getConfiguration(
     "java-message-key-navigator"
   );
@@ -124,9 +124,13 @@ export async function findPropertyLocation(
       const lines = fs.readFileSync(fp, "utf-8").split(/\r?\n/);
       const idx = lines.findIndex((l) => l.trim().startsWith(`${key}=`));
       if (idx !== -1) {
+        const keyStart = lines[idx].indexOf(key);
         return {
           filePath: fp,
-          position: new vscode.Position(idx, lines[idx].length),
+          range: new vscode.Range(
+            new vscode.Position(idx, keyStart),
+            new vscode.Position(idx, keyStart + key.length)
+          ),
         };
       }
     }

--- a/test/DefinitionProvider.test.ts
+++ b/test/DefinitionProvider.test.ts
@@ -36,8 +36,11 @@ jest.mock("vscode", () => ({
   Location: class {
     constructor(public uri: any, public range: any) {
       this.uri = uri;
-      this.range = { start: range, end: range };
+      this.range = range;
     }
+  },
+  Range: class {
+    constructor(public start: any, public end: any) {}
   },
 }));
 
@@ -71,7 +74,10 @@ describe("PropertiesDefinitionProvider", () => {
 
     (utils.findPropertyLocation as jest.Mock).mockResolvedValue({
       filePath: "/foo/bar.properties",
-      position: new vscode.Position(3, 5),
+      range: new vscode.Range(
+        new vscode.Position(3, 5),
+        new vscode.Position(3, 12)
+      ),
     });
 
     const res = await provider.provideDefinition(doc as any, position);
@@ -85,6 +91,8 @@ describe("PropertiesDefinitionProvider", () => {
     expect(res.uri.fsPath).toBe("/foo/bar.properties");
     expect(res.range.start.line).toBe(3);
     expect(res.range.start.character).toBe(5);
+    expect(res.range.end.line).toBe(3);
+    expect(res.range.end.character).toBe(12);
   });
 
   it("異常系: ジャンプ先が見つからない場合、nullが返る", async () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -189,7 +189,10 @@ describe("utils.ts", () => {
       const loc = await findPropertyLocation("b");
       assert.ok(loc);
       assert.strictEqual(loc!.filePath, propFile);
-      assert.strictEqual(loc!.position.line, 1);
+      assert.strictEqual(loc!.range.start.line, 1);
+      assert.strictEqual(loc!.range.start.character, 0);
+      assert.strictEqual(loc!.range.end.line, 1);
+      assert.strictEqual(loc!.range.end.character, 1);
     });
   });
 
@@ -587,13 +590,13 @@ describe("utils.ts", () => {
     });
   });
 
-  // ── 2) findPropertyLocation の line.text.length 分岐 ──
-  describe("findPropertyLocation – position.character に line.text.length を使う", () => {
-    it("行末の文字数を character にセットする", async () => {
+  // ── 2) findPropertyLocation のキー範囲計算 ──
+  describe("findPropertyLocation – key の Range を返す", () => {
+    it("キーの開始位置から終了位置までを range にセットする", async () => {
       // 1) 一時ディレクトリと .properties を用意
       const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "test-utils-"));
       const file = path.join(tmp, "app.properties");
-      fs.writeFileSync(file, ["foo=123", "bar=XYZ"].join("\n"), "utf-8");
+      fs.writeFileSync(file, ["foo=123", "  bar=XYZ"].join("\n"), "utf-8");
 
       // 2) customPropertyGlobs に自ファイルを指定
       jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
@@ -607,10 +610,10 @@ describe("utils.ts", () => {
       const loc = await findPropertyLocation("bar");
 
       expect(loc).not.toBeNull();
-      // line=1 (0-origin)
-      expect(loc!.position.line).toBe(1);
-      // lines[1] === "bar=XYZ", length === 7
-      expect(loc!.position.character).toBe("bar=XYZ".length);
+      expect(loc!.range.start.line).toBe(1);
+      expect(loc!.range.start.character).toBe(2);
+      expect(loc!.range.end.line).toBe(1);
+      expect(loc!.range.end.character).toBe(5);
     });
   });
 


### PR DESCRIPTION
## Summary
- bump extension version to v1.0.14 and align release docs/lockfile
- fix Go to Definition to target the exact message-key range in .properties files
- add regression coverage for key-range navigation and keep coverage at 100%

## Verification
- npm run lint
- npm test
- npm run build