### PR TITLE
feat: add argBuilderPatterns setting for placeholder validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ Detects when the number of `{0}`, `{1}`, … placeholders in your `.properties` 
   ```
 
 - 🔍 Treats common exception arguments (e.g. `e`, `ex`, `exceptionObj`) as non-placeholder arguments in logger-style calls
+- 🔍 Recognizes argument-builder methods configured via `argBuilderPatterns` (see [Configuration](#%EF%B8%8F-configuration))
+
+  ```java
+  // With argBuilderPatterns: [{ "pattern": "buildArgs", "argCount": 1 }]
+  // message.properties: PLF1032=Request URI: {0}
+  // → 1 placeholder matches argCount 1 ✅
+  infrastructureLogger.log("PLF1032", buildArgs(requestUri));
+  ```
+
 - ❌ Highlights any mismatch with a red squiggly underline in the editor for immediate correction
 
 **Annotation Key Extraction**  
@@ -107,14 +116,51 @@ Add these to your **User** or **Workspace** `settings.json`:
     "@LogStartEnd\\(.*?end\\s*=\\s*\"([^\\\"]+)\"",
     "@LogStartEnd\\(.*?exception\\s*=\\s*\"([^\\\"]+)\"",
   ],
+
+  // Methods that build argument arrays with a known argument count
+  "java-message-key-navigator.argBuilderPatterns": [
+    { "pattern": "buildArgs", "argCount": 1 },
+    { "pattern": "createLogParams", "argCount": 2 },
+  ],
 }
 ```
 
-| Setting                                   | Description                                                                                                    |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `messageKeyExtractionPatterns` (array)    | Method identifier strings used to detect target calls (e.g. `infrastructureLogger.log`)                        |
-| `annotationKeyExtractionPatterns` (array) | Regex patterns for annotations to scan for keys (e.g. values of `start`, `end`, `exception` in `@LogStartEnd`) |
-| `propertyFileGlobs` (array)               | Glob patterns for your `.properties` files to include in look-up and auto-insertion                            |
+| Setting                                   | Description                                                                                                                                                |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `messageKeyExtractionPatterns` (array)    | Method identifier strings used to detect target calls (e.g. `infrastructureLogger.log`)                                                                    |
+| `annotationKeyExtractionPatterns` (array) | Regex patterns for annotations to scan for keys (e.g. values of `start`, `end`, `exception` in `@LogStartEnd`)                                             |
+| `propertyFileGlobs` (array)               | Glob patterns for your `.properties` files to include in look-up and auto-insertion                                                                        |
+| `argBuilderPatterns` (array of objects)   | Methods that build argument arrays with a known count. Each entry has `pattern` (method name) and `argCount` (number of arguments it produces). See below. |
+
+### argBuilderPatterns
+
+When placeholder validation encounters a method call as the argument expression instead of an inline array literal (`new Object[] {…}`), it cannot determine the argument count statically. The `argBuilderPatterns` setting lets you tell the extension how many arguments a given helper method produces.
+
+```jsonc
+"java-message-key-navigator.argBuilderPatterns": [
+  { "pattern": "buildArgs", "argCount": 1 },
+  { "pattern": "createLogParams", "argCount": 2 }
+]
+```
+
+**How it works:**
+
+- `pattern` — The method name to match. Matches bare calls (`buildArgs(…)`), qualified calls (`Utils.buildArgs(…)`), and `this.buildArgs(…)`.
+- `argCount` — The number of placeholder arguments the method produces. Used in place of static counting for placeholder validation.
+
+**Example:**
+
+```java
+// message.properties: PLF1032=Request URI: {0}
+
+// Without argBuilderPatterns → extension cannot validate argument count
+infrastructureLogger.log("PLF1032", buildArgs(requestUri));
+
+// With { "pattern": "buildArgs", "argCount": 1 } → validates that
+// 1 placeholder ({0}) matches argCount 1 ✅
+```
+
+When no pattern matches, the extension falls back to its default behavior (treating the expression as a single argument).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,26 @@
           "type": "array",
           "description": "Regex patterns to extract I18N keys from annotations.",
           "default": []
+        },
+        "java-message-key-navigator.argBuilderPatterns": {
+          "type": "array",
+          "description": "Defines methods that build argument arrays with a known argument count. When a method call matching a pattern is used as the argument expression, the configured argCount is used for placeholder validation.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pattern": {
+                "type": "string",
+                "description": "Method name to match (e.g. \"buildArgs\"). Matches bare calls and qualified calls like Utils.buildArgs(...)."
+              },
+              "argCount": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The number of arguments the method produces."
+              }
+            },
+            "required": ["pattern", "argCount"]
+          },
+          "default": []
         }
       }
     },

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -1,6 +1,11 @@
 import * as vscode from "vscode";
 import { getMessageValueForKey } from "./utils";
 
+interface ArgBuilderPattern {
+  pattern: string;
+  argCount: number;
+}
+
 export async function validatePlaceholders(
   document: vscode.TextDocument,
   collection: vscode.DiagnosticCollection
@@ -10,9 +15,12 @@ export async function validatePlaceholders(
   const seenDiagnostics = new Set<string>();
   const text = document.getText();
 
-  const patterns = vscode.workspace
-    .getConfiguration("java-message-key-navigator")
-    .get<string[]>("messageKeyExtractionPatterns", []);
+  const config = vscode.workspace.getConfiguration("java-message-key-navigator");
+  const patterns = config.get<string[]>("messageKeyExtractionPatterns", []);
+  const argBuilderPatterns = config.get<ArgBuilderPattern[]>(
+    "argBuilderPatterns",
+    []
+  );
   const regexes = patterns
     .map(normalizeMethodPattern)
     .filter((pat) => pat.length > 0)
@@ -149,7 +157,15 @@ export async function validatePlaceholders(
         } else if (/\.join\s*\(/.test(args[0])) {
           actualArgCount = expectedArgCount;
         } else {
-          actualArgCount = 1;
+          const builderArgCount = matchArgBuilderPattern(
+            args[0],
+            argBuilderPatterns
+          );
+          if (builderArgCount !== null) {
+            actualArgCount = builderArgCount;
+          } else {
+            actualArgCount = 1;
+          }
         }
       } else {
         actualArgCount = args.filter((e) => e.trim() !== "").length;
@@ -315,4 +331,24 @@ function safeSplit(argString: string): string[] {
 
   if (buffer.trim() !== "") {result.push(buffer.trim());}
   return result;
+}
+
+/**
+ * 引数式が argBuilderPatterns に定義されたメソッド呼び出しにマッチするか判定し、
+ * マッチした場合は設定された argCount を返す。マッチしなければ null。
+ */
+function matchArgBuilderPattern(
+  argText: string,
+  patterns: ArgBuilderPattern[]
+): number | null {
+  const trimmed = argText.trim();
+  for (const { pattern, argCount } of patterns) {
+    const esc = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // buildArgs(...), Utils.buildArgs(...), this.buildArgs(...) にマッチ
+    const re = new RegExp(`(?:^|\\.)${esc}\\s*\\(`);
+    if (re.test(trimmed)) {
+      return argCount;
+    }
+  }
+  return null;
 }

--- a/test/diagnostic.test.ts
+++ b/test/diagnostic.test.ts
@@ -41,10 +41,12 @@ describe("validatePlaceholders", () => {
   let text: string;
   let offset: number;
   let patterns: string[];
+  let argBuilderPatterns: Array<{ pattern: string; argCount: number }>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     seen = [];
+    argBuilderPatterns = [];
 
     doc = {
       languageId: "java",
@@ -63,7 +65,11 @@ describe("validatePlaceholders", () => {
     } as any;
 
     (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
-      get: (_key: string, _def: any) => patterns,
+      get: (key: string, def: any) => {
+        if (key === "messageKeyExtractionPatterns") return patterns;
+        if (key === "argBuilderPatterns") return argBuilderPatterns;
+        return def;
+      },
     });
   });
 
@@ -674,5 +680,231 @@ describe("validatePlaceholders", () => {
     expect(messages.some((m) => /プレースホルダー.*\{2\}.*\{5\}/.test(m))).toBe(
       true
     );
+  });
+
+  // ===== argBuilderPatterns テスト =====
+
+  it("argBuilderPattern にマッチするメソッド呼び出しは設定された argCount で検証されること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 1 }];
+    text = `log("MSG", buildArgs(requestUri))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("argBuilderPattern にマッチするが argCount がプレースホルダー数と不一致の場合はエラーになること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 1 }];
+    text = `log("MSG", buildArgs(requestUri))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0} {1}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 1);
+    expect(seen[0][0].message).toMatch(/Placeholder count.*argument count/);
+  });
+
+  it("argBuilderPattern が修飾付き呼び出し（Utils.buildArgs）にマッチすること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 2 }];
+    text = `log("MSG", Utils.buildArgs(a, b))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0} {1}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("argBuilderPattern に未登録のメソッド呼び出しは既存ロジック（argCount=1）にフォールスルーすること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 1 }];
+    text = `log("MSG", someOtherMethod(x))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0} {1}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 1);
+    expect(seen[0][0].message).toMatch(/Placeholder count.*argument count/);
+  });
+
+  it("argBuilderPatterns が空の場合は既存動作が維持されること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [];
+    text = `log("MSG", buildArgs(x))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0}");
+
+    await validatePlaceholders(doc, collection);
+    // buildArgs(x) は単一引数扱い → actualArgCount=1, expectedArgCount=1 → 一致
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("複数の argBuilderPatterns から正しいパターンがマッチすること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [
+      { pattern: "buildArgs", argCount: 1 },
+      { pattern: "createLogParams", argCount: 2 },
+    ];
+    text = `log("MSG", createLogParams(a, b))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0} {1}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("this.buildArgs() のような this 修飾付き呼び出しにマッチすること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 1 }];
+    text = `log("MSG", this.buildArgs(requestUri))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("深いパッケージ修飾（a.b.c.buildArgs）にマッチすること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 3 }];
+    text = `log("MSG", com.example.Utils.buildArgs(a, b, c))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0} {1} {2}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("パターン 'build' が 'buildArgs' に部分一致しないこと", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "build", argCount: 2 }];
+    text = `log("MSG", buildArgs(x))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0}");
+
+    await validatePlaceholders(doc, collection);
+    // "build" は "buildArgs" にマッチしない → フォールスルー → actualArgCount=1
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("argCount: 0 の場合はプレースホルダーなしのメッセージと一致すること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "emptyArgs", argCount: 0 }];
+    text = `log("MSG", emptyArgs())`;
+    getMessageValueForKey.mockResolvedValue("Hello");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("argCount: 0 でプレースホルダーがある場合はエラーになること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "emptyArgs", argCount: 0 }];
+    text = `log("MSG", emptyArgs())`;
+    getMessageValueForKey.mockResolvedValue("Hi {0}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 1);
+    expect(seen[0][0].message).toMatch(/Placeholder count.*argument count/);
+  });
+
+  it("argBuilderPattern + 例外引数（ex）が末尾にある場合は ex が除外されること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 1 }];
+    text = `log("MSG", buildArgs(requestUri), ex)`;
+    getMessageValueForKey.mockResolvedValue("Hi {0}");
+
+    await validatePlaceholders(doc, collection);
+    // args = ["buildArgs(requestUri)", "ex"]
+    // args.length > 1 なので argBuilderPattern 分岐には入らない
+    // 末尾 ex が除外ロジックで処理され、残り1個で一致
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("argBuilderPattern + locale 引数が末尾にある場合は locale が除外されること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 1 }];
+    text = `log("MSG", buildArgs(requestUri), Locale.JAPAN)`;
+    getMessageValueForKey.mockResolvedValue("Hi {0}");
+
+    await validatePlaceholders(doc, collection);
+    // locale が除外 → args = ["buildArgs(requestUri)"]
+    // args.length === 1 → argBuilderPattern マッチ → argCount=1 → 一致
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("メソッド名の前にスペースがある場合（buildArgs (x)）にもマッチすること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 1 }];
+    text = `log("MSG", buildArgs (requestUri))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("同一ファイルに複数の argBuilderPattern 対象呼び出しがある場合、それぞれ検証されること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [
+      { pattern: "buildArgs", argCount: 1 },
+      { pattern: "createParams", argCount: 2 },
+    ];
+    text = `log("MSG1", buildArgs(a)); log("MSG2", createParams(a, b))`;
+    getMessageValueForKey
+      .mockResolvedValueOnce("Hi {0}")       // MSG1: 1個 → buildArgs argCount=1 → OK
+      .mockResolvedValueOnce("Hi {0} {1}");  // MSG2: 2個 → createParams argCount=2 → OK
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("同一ファイルで一方が一致・他方が不一致の場合、不一致のみエラーになること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [
+      { pattern: "buildArgs", argCount: 1 },
+      { pattern: "createParams", argCount: 2 },
+    ];
+    text = `log("MSG1", buildArgs(a)); log("MSG2", createParams(a, b))`;
+    getMessageValueForKey
+      .mockResolvedValueOnce("Hi {0}")           // MSG1: OK
+      .mockResolvedValueOnce("Hi {0} {1} {2}");  // MSG2: 3個 vs argCount=2 → NG
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 1);
+    expect(seen[0][0].message).toMatch(/Placeholder count \(3\).*argument count \(2\)/);
+  });
+
+  it("配列リテラルが優先され、argBuilderPattern は適用されないこと", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "buildArgs", argCount: 3 }];
+    // new Object[] { ... } は配列リテラルとして先に処理される
+    text = `log("MSG", new Object[] { "A", "B" })`;
+    getMessageValueForKey.mockResolvedValue("Hi {0} {1}");
+
+    await validatePlaceholders(doc, collection);
+    // 配列リテラルとして要素2個 → プレースホルダー2個 → 一致
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("パターン名に正規表現の特殊文字が含まれていても正しくエスケープされること", async () => {
+    patterns = ["log"];
+    argBuilderPatterns = [{ pattern: "build$Args", argCount: 1 }];
+    text = `log("MSG", build$Args(x))`;
+    getMessageValueForKey.mockResolvedValue("Hi {0}");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
   });
 });


### PR DESCRIPTION
## Summary

- Add new `argBuilderPatterns` setting that lets users define helper methods and their known argument counts for placeholder validation
- When args are built by methods like `buildArgs(requestUri)` instead of inline `new Object[] {…}`, the extension now uses the configured `argCount` instead of falling back to `actualArgCount = 1`
- Supports bare calls (`buildArgs(…)`), qualified calls (`Utils.buildArgs(…)`), and `this.buildArgs(…)`

## Configuration

```jsonc
"java-message-key-navigator.argBuilderPatterns": [
  { "pattern": "buildArgs", "argCount": 1 },
  { "pattern": "createLogParams", "argCount": 2 }
]
```

## Changes

- **package.json**: New `argBuilderPatterns` setting with JSON Schema validation
- **src/diagnostic.ts**: `ArgBuilderPattern` type, `matchArgBuilderPattern()` function, arg count branch
- **test/diagnostic.test.ts**: 18 new tests (mock update + 6 core + 12 edge cases), 222 total, 100% coverage
- **README.md**: Feature description, configuration example, and detailed `argBuilderPatterns` subsection

## Test plan

- [x] All 222 tests pass with 100% coverage
- [x] Existing tests unaffected by mock update (key-based config lookup)
- [x] Pattern matching: bare, qualified, `this.` prefix, deep package paths
- [x] Partial match prevention: pattern `"build"` does not match `buildArgs`
- [x] argCount 0 case (no placeholders)
- [x] Interaction with exception args (ex) and locale args
- [x] Multiple patterns with correct selection
- [x] Array literal priority over argBuilderPattern
- [x] Special regex characters in pattern names