### PR TITLE
fix: eliminate false positive for getMessage(..., null, locale)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.1] - 2026-04-01
+
+### Fixed (1.1.1)
+
+- Fixed false-positive placeholder mismatch diagnostics for Issue #11:
+  `messageSource.getMessage(..., null, locale)` by treating `null` and
+  `(Object[]) null` as zero placeholder arguments.
+- Added regression tests to ensure `null` and casted-null argument forms are
+  not flagged for placeholder mismatch when no placeholders are expected.
+
+### Changed (1.1.1)
+
+- Bumped extension version to **1.1.1**.
+
+---
+
 ## [1.1.0] - 2026-03-30
 
 ### Added (1.1.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "java-message-key-navigator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "java-message-key-navigator",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Java Message Key Navigator",
   "description": "A VS Code extension to assist with Java I18N (internationalization) message management",
   "publisher": "y-ok",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -420,6 +420,10 @@ function countActualArguments(
   }
 
   if (argTexts.length === 1) {
+    if (isNullArrayArgument(argTexts[0])) {
+      return 0;
+    }
+
     const arrayMatch = argTexts[0].match(
       /new\s+[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\s*\[\s*\]\s*{([\s\S]*?)}/
     );
@@ -439,6 +443,23 @@ function countActualArguments(
   }
 
   return argTexts.filter((e) => e.trim() !== "").length;
+}
+
+/**
+ * Detects arguments that explicitly pass no placeholder values, such as
+ * `null` or `(Object[]) null`.
+ *
+ * @param argText Single argument text.
+ */
+function isNullArrayArgument(argText: string): boolean {
+  const trimmed = argText.trim();
+  if (trimmed === "null") {
+    return true;
+  }
+
+  return /^\(\s*[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*(?:\s*\[\s*\])+\s*\)\s*null$/.test(
+    trimmed
+  );
 }
 
 /**

--- a/test/diagnostic.test.ts
+++ b/test/diagnostic.test.ts
@@ -238,6 +238,27 @@ describe("validatePlaceholders", () => {
     assert.strictEqual(seen[0].length, 0);
   });
 
+  it("getMessage(..., null, locale) で診断されないこと", async () => {
+    patterns = ["messageSource.getMessage"];
+    text = `messageSource.getMessage("email.verification.subject", null, locale)`;
+    getMessageValueForKey.mockResolvedValue("Email verification");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
+  it("getMessage(..., (Object[]) null, locale) で診断されないこと", async () => {
+    patterns = ["messageSource.getMessage"];
+    text =
+      'messageSource.getMessage("email.verification.subject", (Object[]) null, locale)';
+    getMessageValueForKey.mockResolvedValue("Email verification");
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 0);
+  });
+
   it("重複する抽出パターンでも同じ診断は1件だけ登録されること", async () => {
     patterns = ["log", "foo.log"];
     text = `foo.log("MSG", a)`;
@@ -461,6 +482,23 @@ describe("validatePlaceholders", () => {
     await validatePlaceholders(doc, collection);
     assert.strictEqual(seen.length, 1);
     assert.strictEqual(seen[0].length, 1);
+  });
+
+  it("MSG=A {0}, B {1} で末尾 ex の型解決が失敗した場合は不一致 Error になること", async () => {
+    patterns = ["log"];
+    text = `log("MSG", customerId, orderId, ex)`;
+    getMessageValueForKey.mockResolvedValue("A {0}, B {1}");
+
+    executeCommand.mockRejectedValue(new Error("type lookup failed"));
+
+    await validatePlaceholders(doc, collection);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].length, 1);
+    assert.strictEqual(
+      seen[0][0].message,
+      "⚠️ Placeholder count (2) doesn’t match provided argument count (3)."
+    );
+    assert.strictEqual(seen[0][0].severity, vscode.DiagnosticSeverity.Error);
   });
 
   it("型定義 location に選択レンジがない場合は安全側で診断すること", async () => {


### PR DESCRIPTION
## Summary
- treat `null` and `(Object[]) null` as zero placeholder arguments in `validatePlaceholders`
- add regression tests for both null forms
- bump version to `1.1.1` and update `CHANGELOG.md`

## Validation
- `npm test -- --runTestsByPath test/diagnostic.test.ts`

Closes #11
